### PR TITLE
Exclude postscriptBlueScale from rounding.

### DIFF
--- a/Lib/fontMath/mathInfo.py
+++ b/Lib/fontMath/mathInfo.py
@@ -285,9 +285,12 @@ class MathInfo(object):
         >>> sorted(expected) == sorted(written)
         True
         """
+        excludeFromRounding = ['postscriptBlueScale']
         copiedInfo = self.copy()
         # basic attributes
         for attr, (formatter, factorIndex) in _infoAttrs.items():
+            if attr in excludeFromRounding:
+                continue
             if hasattr(copiedInfo, attr):
                 v = getattr(copiedInfo, attr)
                 if v is not None:


### PR DESCRIPTION
postscriptBlueScale is not a geometric value and does not need to be rounded.
