### PR TITLE
use otRound for rounding to int; allow to globally set rounding funcs

### DIFF
--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -1,7 +1,6 @@
 from __future__ import division
 import math
 from fontTools.misc.py23 import round3
-from fontTools.misc.fixedTools import otRound
 import sys
 
 __all__ = [
@@ -77,26 +76,15 @@ def setRoundFloatFunction(func):
     _ROUND_FLOAT_FUNC = func
 
 
-_ROUND_INTEGER_FUNC = otRound
+_ROUND_INTEGER_FUNC = round3
 _ROUND_FLOAT_FUNC = round3
 
 
 def _roundNumber(value, ndigits=None):
-    """When ndigits is None, rounds float value to nearest integer towards
-    +Infinity.
-    For fractional values of 0.5 and higher, take the next higher integer;
-    for other fractional values, truncate.
-
-    When ndigits is not None, use the Python 3 built-in round function,
-    which returns a float rounded with ndigits precision using the Banker's
-    rounding algorithm.
+    """Round number using the Python 3 built-in round function.
 
     You can change the default rounding functions using setRoundIntegerFunction
     and/or setRoundFloatFunction.
-
-    https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview
-    https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166
-    https://github.com/robotools/fontMath/issues/148
     """
     if ndigits is not None:
         return _ROUND_FLOAT_FUNC(value, ndigits)

--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import math
-from fontTools.misc.py23 import round3 as _roundNumber
+from fontTools.misc.py23 import round3
+from fontTools.misc.fixedTools import otRound
 import sys
 
 __all__ = [
@@ -52,6 +53,54 @@ def factorAngle(angle, f, func):
             func(y, f2), func(x, f1)
         )
     )
+
+
+def setRoundIntegerFunction(func):
+    """ Globally set function for rounding floats to integers.
+
+    The function signature must be:
+
+        def func(value: float) -> int
+    """
+    global _ROUND_INTEGER_FUNC
+    _ROUND_INTEGER_FUNC = func
+
+
+def setRoundFloatFunction(func):
+    """ Globally set function for rounding floats within given precision.
+
+    The function signature must be:
+
+        def func(value: float, ndigits: int) -> float
+    """
+    global _ROUND_FLOAT_FUNC
+    _ROUND_FLOAT_FUNC = func
+
+
+_ROUND_INTEGER_FUNC = otRound
+_ROUND_FLOAT_FUNC = round3
+
+
+def _roundNumber(value, ndigits=None):
+    """When ndigits is None, rounds float value to nearest integer towards
+    +Infinity.
+    For fractional values of 0.5 and higher, take the next higher integer;
+    for other fractional values, truncate.
+
+    When ndigits is not None, use the Python 3 built-in round function,
+    which returns a float rounded with ndigits precision using the Banker's
+    rounding algorithm.
+
+    You can change the default rounding functions using setRoundIntegerFunction
+    and/or setRoundFloatFunction.
+
+    https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview
+    https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166
+    https://github.com/robotools/fontMath/issues/148
+    """
+    if ndigits is not None:
+        return _ROUND_FLOAT_FUNC(value, ndigits)
+    return _ROUND_INTEGER_FUNC(value)
 
 
 if __name__ == "__main__":

--- a/Lib/fontMath/test/test_mathFunctions.py
+++ b/Lib/fontMath/test/test_mathFunctions.py
@@ -1,6 +1,9 @@
 import unittest
+from fontTools.misc.py23 import round2, round3
 from fontMath.mathFunctions import (
-    add, addPt, sub, subPt, mul, mulPt, div, divPt, factorAngle, _roundNumber
+    add, addPt, sub, subPt, mul, mulPt, div, divPt, factorAngle, _roundNumber,
+    setRoundIntegerFunction, setRoundFloatFunction,
+    _ROUND_INTEGER_FUNC, _ROUND_FLOAT_FUNC,
 )
 
 
@@ -53,11 +56,11 @@ class MathFunctionsTest(unittest.TestCase):
         self.assertEqual(_roundNumber(0.1), 0)
         self.assertEqual(_roundNumber(0.99), 1)
         self.assertEqual(_roundNumber(0.499), 0)
-        self.assertEqual(_roundNumber(0.5), 0)
+        self.assertEqual(_roundNumber(0.5), 1)
         self.assertEqual(_roundNumber(-0.499), 0)
         self.assertEqual(_roundNumber(-0.5), 0)
         self.assertEqual(_roundNumber(1.5), 2)
-        self.assertEqual(_roundNumber(-1.5), -2)
+        self.assertEqual(_roundNumber(-1.5), -1)
 
     def test_roundNumber_to_float(self):
         # round to float with specified decimals:
@@ -66,6 +69,24 @@ class MathFunctionsTest(unittest.TestCase):
         self.assertEqual(_roundNumber(0.3333, 1), 0.3)
         self.assertEqual(_roundNumber(0.3333, 2), 0.33)
         self.assertEqual(_roundNumber(0.3333, 3), 0.333)
+
+    def test_set_custom_round_integer_func(self):
+        default = _ROUND_INTEGER_FUNC
+        try:
+            setRoundIntegerFunction(round3)
+            self.assertEqual(_roundNumber(0.5), 0)
+            self.assertEqual(_roundNumber(-1.5), -2)
+        finally:
+            setRoundIntegerFunction(default)
+
+    def test_set_custom_round_float_func(self):
+        default = _ROUND_FLOAT_FUNC
+        try:
+            setRoundFloatFunction(round2)
+            self.assertEqual(_roundNumber(0.55, 1), 0.6)
+            self.assertEqual(_roundNumber(-1.555, 2), -1.55)
+        finally:
+            setRoundIntegerFunction(default)
 
 
 if __name__ == "__main__":

--- a/Lib/fontMath/test/test_mathFunctions.py
+++ b/Lib/fontMath/test/test_mathFunctions.py
@@ -1,5 +1,6 @@
 import unittest
-from fontTools.misc.py23 import round2, round3
+from fontTools.misc.py23 import round2
+from fontTools.misc.fixedTools import otRound
 from fontMath.mathFunctions import (
     add, addPt, sub, subPt, mul, mulPt, div, divPt, factorAngle, _roundNumber,
     setRoundIntegerFunction, setRoundFloatFunction,
@@ -56,11 +57,11 @@ class MathFunctionsTest(unittest.TestCase):
         self.assertEqual(_roundNumber(0.1), 0)
         self.assertEqual(_roundNumber(0.99), 1)
         self.assertEqual(_roundNumber(0.499), 0)
-        self.assertEqual(_roundNumber(0.5), 1)
+        self.assertEqual(_roundNumber(0.5), 0)
         self.assertEqual(_roundNumber(-0.499), 0)
         self.assertEqual(_roundNumber(-0.5), 0)
         self.assertEqual(_roundNumber(1.5), 2)
-        self.assertEqual(_roundNumber(-1.5), -1)
+        self.assertEqual(_roundNumber(-1.5), -2)
 
     def test_roundNumber_to_float(self):
         # round to float with specified decimals:
@@ -73,9 +74,9 @@ class MathFunctionsTest(unittest.TestCase):
     def test_set_custom_round_integer_func(self):
         default = _ROUND_INTEGER_FUNC
         try:
-            setRoundIntegerFunction(round3)
-            self.assertEqual(_roundNumber(0.5), 0)
-            self.assertEqual(_roundNumber(-1.5), -2)
+            setRoundIntegerFunction(otRound)
+            self.assertEqual(_roundNumber(0.5), 1)
+            self.assertEqual(_roundNumber(-1.5), -1)
         finally:
             setRoundIntegerFunction(default)
 


### PR DESCRIPTION
For consistency with generating variable font instances with varLib, this PR changes the default rounding integer function to fontTools' `otRound`, which rounds a float to nearest integer towards the +Infinity following the algorithm described in [OT Variations Overview](https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview).
For rounding floats to given decimal precision (when `ndigits` parameter is given) the built-in Python 3 round() function is still used by default.

The PR also adds functions to globally override the rounding functions.

This of course is a breaking change, as it changes the default integer rounding function from round3 to otRound.

We may wish alternatively to keep the default to round3, and then the caller is responsible for setting it to otRound if they wish so.

Fixes https://github.com/robotools/fontMath/issues/148

@madig PTAL