### PR TITLE
mathInfo: handle case when one operand is None and attribute is number list

### DIFF
--- a/Lib/fontMath/mathInfo.py
+++ b/Lib/fontMath/mathInfo.py
@@ -59,18 +59,20 @@ class MathInfo(object):
                     v = self._processMathOneNumberList(a, b, func)
                 else:
                     v = self._processMathOneNumber(a, b, func)
+            # when one of the terms is undefined, we treat addition and subtraction
+            # differently...
+            # https://github.com/robotools/fontMath/issues/175
+            # https://github.com/robotools/fontMath/issues/136
             elif a is not None and b is None:
-                #v = a
                 if func == add:
                     v = a
                 else:
-                    v = 0
+                    v = None if attr in _numberListAttrs else 0
             elif b is not None and a is None:
-                #v = b
                 if func is add:
                     v = b
                 else:
-                    v = 0
+                    v = None if attr in _numberListAttrs else 0
             if v is not None:
                 setattr(copiedInfo, attr, v)
         # special attributes
@@ -420,6 +422,12 @@ _infoAttrs = dict(
     # this will be handled in a special way
     # postscriptWeightName=unicode
 )
+
+_numberListAttrs = {
+    attr
+    for attr, (formatter, _) in _infoAttrs.items()
+    if formatter is _numberListFormatter
+}
 
 _postscriptWeightNameOptions = {
     100 : "Thin",

--- a/Lib/fontMath/test/test_mathInfo.py
+++ b/Lib/fontMath/test/test_mathInfo.py
@@ -1,6 +1,6 @@
 import unittest
 from fontMath.mathFunctions import _roundNumber
-from fontMath.mathInfo import MathInfo
+from fontMath.mathInfo import MathInfo, _numberListAttrs
 
 
 class MathInfoTest(unittest.TestCase):
@@ -213,6 +213,27 @@ class MathInfoTest(unittest.TestCase):
                 expectedValue = _roundNumber(value)
             expected[attr] = expectedValue
         self.assertEqual(sorted(expected), sorted(written))
+
+    def test_sub_undefined_number_list_does_nothing(self):
+        self.assertIn("postscriptBlueValues", _numberListAttrs)
+
+        info1 = _TestInfoObject()
+        info1.postscriptBlueValues = None
+        m1 = MathInfo(info1)
+
+        info2 = _TestInfoObject()
+        info2.postscriptBlueValues = [1, 2, 3]
+        m2 = MathInfo(info2)
+
+        m3 = m2 - m1
+
+        self.assertEqual(m3.postscriptBlueValues, [1, 2, 3])
+
+        m4 = m1 - m2
+
+        self.assertEqual(m4.postscriptBlueValues, None)
+
+
 # ----
 # Test Data
 # ----


### PR DESCRIPTION
Fixes #175 

... or does it?