### PR TITLE
Fix multiplication of fontinfo slant and italic angles

### DIFF
--- a/Lib/fontMath/mathFunctions.py
+++ b/Lib/fontMath/mathFunctions.py
@@ -44,6 +44,10 @@ def divPt(pt, f):
 
 def factorAngle(angle, f, func):
     (f1, f2) = f
+    # If both factors are equal, assume a scalar factor and scale the angle as such.
+    if f1 == f2:
+        return func(angle, f1)
+    # Otherwise, scale x and y components separately.
     rangle = math.radians(angle)
     x = math.cos(rangle)
     y = math.sin(rangle)

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -392,7 +392,7 @@ class MathGlyphTest(unittest.TestCase):
         ]
         glyph2 = glyph1 * 3
         expected = [
-            dict(x=1 * 3, y=3 * 3, angle=5, name="test", identifier="1",
+            dict(x=1 * 3, y=3 * 3, angle=15, name="test", identifier="1",
                  color="0,0,0,0")
         ]
         self.assertEqual(glyph2.guidelines, expected)
@@ -428,11 +428,11 @@ class MathGlyphTest(unittest.TestCase):
         glyph4 = glyph1 - glyph2
         self.assertEqual(glyph4.guidelines, expected_sub)
 
-        expected_mul = [dict(name="foo", identifier="1", x=0, y=0, angle=359)]
+        expected_mul = [dict(name="foo", identifier="1", x=0, y=0, angle=355)]
         glyph5 = glyph2 * 5
         self.assertEqual(glyph5.guidelines, expected_mul)
 
-        expected_div = [dict(name="foo", identifier="1", x=0, y=0, angle=359)]
+        expected_div = [dict(name="foo", identifier="1", x=0, y=0, angle=71.8)]
         glyph6 = glyph2 / 5
         self.assertEqual(glyph6.guidelines, expected_div)
 

--- a/Lib/fontMath/test/test_mathInfo.py
+++ b/Lib/fontMath/test/test_mathInfo.py
@@ -95,6 +95,26 @@ class MathInfoTest(unittest.TestCase):
             expected[attr] = expectedValue
         self.assertEqual(sorted(expected.items()), sorted(written.items()))
 
+    def test_angle(self):
+        info1 = MathInfo(_TestInfoObject())
+        info1.italicAngle = 10
+
+        info2 = info1 - info1
+        self.assertEqual(info2.italicAngle, 0)
+        info2 = info1 + info1 + info1
+        self.assertEqual(info2.italicAngle, 30)
+        info2 = 10 * info1
+        self.assertEqual(info2.italicAngle, 100)
+        info2 = info1 / 20 
+        self.assertEqual(info2.italicAngle, 0.5)
+
+        info2 = info1 * 2.5
+        self.assertEqual(info2.italicAngle, 25)
+        info2 = info1 * (2.5, 2.5)
+        self.assertEqual(info2.italicAngle, 25)
+        info2 = info1 * (2.5, 5)
+        self.assertEqual(round(info2.italicAngle), 19)
+
     def test_mul_data_subset(self):
         info1 = MathInfo(_TestInfoObject(_testDataSubset))
         info2 = info1 * 2.5
@@ -268,7 +288,7 @@ _testData = dict(
     xHeight=400,
     capHeight=650,
     ascender=700,
-    italicAngle=0,
+    italicAngle=5,
     # head
     openTypeHeadLowestRecPPEM=5,
     # hhea
@@ -304,7 +324,7 @@ _testData = dict(
     openTypeVheaCaretSlopeRun=1,
     openTypeVheaCaretOffset=1,
     # postscript
-    postscriptSlantAngle=0,
+    postscriptSlantAngle=-5,
     postscriptUnderlineThickness=100,
     postscriptUnderlinePosition=-150,
     postscriptBlueValues=[-10, 0, 400, 410, 650, 660, 700, 710],


### PR DESCRIPTION
A fontinfo's `italicAngle` and `postscriptSlantAngle` do not seem to interpolate correctly.

Initially found with this reproducer (the last assert fails):

```python
from fontmake import instantiator
from fontTools.designspaceLib import DesignSpaceDocument
from ufoLib2 import Font

d = DesignSpaceDocument()
d.addAxisDescriptor(name="Weight", tag="wght", minimum=300, default=300, maximum=900)
d.addAxisDescriptor(name="Slant", tag="slnt", minimum=-20, default=0, maximum=0)
d.addSourceDescriptor(location={"Weight": 300, "Slant": 0}, font=Font())
d.addSourceDescriptor(location={"Weight": 500, "Slant": 0}, font=Font())
d.addSourceDescriptor(location={"Weight": 900, "Slant": 0}, font=Font())
d.addSourceDescriptor(location={"Weight": 300, "Slant": -20}, font=Font())
d.addSourceDescriptor(location={"Weight": 500, "Slant": -20}, font=Font())
d.addSourceDescriptor(location={"Weight": 900, "Slant": -20}, font=Font())
d.addInstanceDescriptor(styleName="1", location={"Weight": 400, "Slant": 0})
d.addInstanceDescriptor(styleName="2", location={"Weight": 400, "Slant": -12})
d.addInstanceDescriptor(styleName="3", location={"Weight": 400, "Slant": -20})
d.findDefault()

for s in d.sources:
    s.font.info.italicAngle = s.location["Slant"]

assert [s.font.info.italicAngle for s in d.sources] == [
    0.0,
    0.0,
    0.0,
    -20.0,
    -20.0,
    -20.0,
]

inst = instantiator.Instantiator.from_designspace(d)
for i in d.instances:
    i.font = inst.generate_instance(i)

instance_angles = [i.font.info.italicAngle for i in d.instances]
assert instance_angles == [0, -12, -20], instance_angles
```

After some digging with @belluzj, we found that `test_mul` fails on these two attributes if they're non-zero, as if they're skipped. More digging required.