### PR TITLE
Stricter handling of offcurves

### DIFF
--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -397,21 +397,18 @@ class MathGlyphPen(AbstractPointPen):
         holdingOffCurves = []
         for index, point in enumerate(points):
             segmentType = point[0]
-            if self.strict:
-                contourPoints.append(point)
-            else:
-                if segmentType == "line":
-                    pt, smooth, name, identifier = point[1:]
-                    prevPt = points[index - 1][1]
-                    if index == 0:
-                        holdingOffCurves.append((None, prevPt, False, None, None))
-                        holdingOffCurves.append((None, pt, False, None, None))
-                    else:
-                        contourPoints.append((None, prevPt, False, None, None))
-                        contourPoints.append((None, pt, False, None, None))
-                    contourPoints.append(("curve", pt, smooth, name, identifier))
+            if segmentType == "line" and not self.strict:
+                pt, smooth, name, identifier = point[1:]
+                prevPt = points[index - 1][1]
+                if index == 0:
+                    holdingOffCurves.append((None, prevPt, False, None, None))
+                    holdingOffCurves.append((None, pt, False, None, None))
                 else:
-                    contourPoints.append(point)
+                    contourPoints.append((None, prevPt, False, None, None))
+                    contourPoints.append((None, pt, False, None, None))
+                contourPoints.append(("curve", pt, smooth, name, identifier))
+            else:
+                contourPoints.append(point)
         contourPoints.extend(holdingOffCurves)
 
     def beginPath(self, identifier=None):

--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -70,7 +70,7 @@ class MathGlyph(object):
         same order as the original.
     """
 
-    def __init__(self, glyph, scaleComponentTransform=True):
+    def __init__(self, glyph, scaleComponentTransform=True, strict=False):
         """Initialize a new MathGlyph object.
 
         Args:
@@ -81,10 +81,15 @@ class MathGlyph(object):
                 multiplied by the given scalar. If scaleComponentTransform is False, then
                 only the component's xOffset and yOffset attributes are scaled, whereas the
                 xScale, xyScale, yxScale and yScale attributes are kept unchanged.
+            strict (bool): when set to False, offcurve points will be added to all 
+                straight segments to improve compatibility. Any offcurves that are
+                still on-point will be filtered when extracted. When set to True,
+                no offcurves will be added or filtered. 
         """
         self.scaleComponentTransform = scaleComponentTransform
         self.contours = []
         self.components = []
+        self.strict = strict
         if glyph is None:
             self.anchors = []
             self.guidelines = []
@@ -96,7 +101,7 @@ class MathGlyph(object):
             self.height = None
             self.note = None
         else:
-            p = MathGlyphPen(self)
+            p = MathGlyphPen(self, strict=self.strict)
             glyph.drawPoints(p)
             self.anchors = [dict(anchor) for anchor in glyph.anchors]
             self.guidelines = [_expandGuideline(guideline) for guideline in glyph.guidelines]
@@ -323,8 +328,11 @@ class MathGlyph(object):
         glyph.clearAnchors()
         glyph.clearGuidelines()
         glyph.lib.clear()
-        cleanerPen = FilterRedundantPointPen(pointPen)
-        self.drawPoints(cleanerPen)
+        if self.strict:
+            self.drawPoints(pointPen)
+        else:
+            cleanerPen = FilterRedundantPointPen(pointPen)
+            self.drawPoints(cleanerPen)
         glyph.anchors = [dict(anchor) for anchor in self.anchors]
         glyph.guidelines = [_compressGuideline(guideline) for guideline in self.guidelines]
         glyph.image = _compressImage(self.image)
@@ -348,7 +356,8 @@ class MathGlyphPen(AbstractPointPen):
     Point pen for building MathGlyph data structures.
     """
 
-    def __init__(self, glyph=None):
+    def __init__(self, glyph=None, strict=False):
+        self.strict = strict # do not add offcurvess
         if glyph is None:
             self.contours = []
             self.components = []
@@ -388,18 +397,21 @@ class MathGlyphPen(AbstractPointPen):
         holdingOffCurves = []
         for index, point in enumerate(points):
             segmentType = point[0]
-            if segmentType == "line":
-                pt, smooth, name, identifier = point[1:]
-                prevPt = points[index - 1][1]
-                if index == 0:
-                    holdingOffCurves.append((None, prevPt, False, None, None))
-                    holdingOffCurves.append((None, pt, False, None, None))
-                else:
-                    contourPoints.append((None, prevPt, False, None, None))
-                    contourPoints.append((None, pt, False, None, None))
-                contourPoints.append(("curve", pt, smooth, name, identifier))
-            else:
+            if self.strict:
                 contourPoints.append(point)
+            else:
+                if segmentType == "line":
+                    pt, smooth, name, identifier = point[1:]
+                    prevPt = points[index - 1][1]
+                    if index == 0:
+                        holdingOffCurves.append((None, prevPt, False, None, None))
+                        holdingOffCurves.append((None, pt, False, None, None))
+                    else:
+                        contourPoints.append((None, prevPt, False, None, None))
+                        contourPoints.append((None, pt, False, None, None))
+                    contourPoints.append(("curve", pt, smooth, name, identifier))
+                else:
+                    contourPoints.append(point)
         contourPoints.extend(holdingOffCurves)
 
     def beginPath(self, identifier=None):

--- a/Lib/fontMath/test/test_mathGlyph.py
+++ b/Lib/fontMath/test/test_mathGlyph.py
@@ -543,6 +543,27 @@ class MathGlyphPenTest(unittest.TestCase):
         self.assertEqual(pen.contours[-1]["points"], expected)
         self.assertEqual(pen.contours[-1]["identifier"], 'contour 1')
 
+    def test_pen_with_lines_strict(self):
+        pen = MathGlyphPen(strict=True)
+        pen.beginPath(identifier="contour 1")
+        pen.addPoint((0,   100), "line", smooth=False, name="name 1",
+                     identifier="point 1")
+        pen.addPoint((100, 100), "line", smooth=False, name="name 2",
+                     identifier="point 2")
+        pen.addPoint((100, 0),   "line", smooth=False, name="name 3",
+                     identifier="point 3")
+        pen.addPoint((0,   0),   "line", smooth=False, name="name 4",
+                     identifier="point 4")
+        pen.endPath()
+        expected = [
+            ("line", (0,   100), False, "name 1", "point 1"),
+            ("line", (100, 100), False, "name 2", "point 2"),
+            ("line", (100, 0),   False, "name 3", "point 3"),
+            ("line", (0,   0),   False, "name 4", "point 4"),
+        ]
+        self.assertEqual(pen.contours[-1]["points"], expected)
+        self.assertEqual(pen.contours[-1]["identifier"], 'contour 1')
+
     def test_pen_with_lines_and_curves(self):
         pen = MathGlyphPen()
         pen.beginPath(identifier="contour 1")
@@ -566,6 +587,39 @@ class MathGlyphPenTest(unittest.TestCase):
             (None,    (0,   50), False, None,     None),
             (None,    (50, 100), False, None,     None),
             ("curve", (50, 100), False, "name 2", "point 2"),
+            (None,    (75, 100), False, None,     None),
+            (None,    (100, 75), False, None,     None),
+            ("curve", (100, 50), True, "name 3", "point 3"),
+            (None,    (100, 25), False, None,     None),
+            (None,    (75,   0), False, None,     None),
+            ("curve", (50,   0), False, "name 4", "point 4"),
+            (None,    (25,   0), False, None,     None),
+            (None,    (0,   25), False, None,     None),
+        ]
+        self.assertEqual(pen.contours[-1]["points"], expected)
+        self.assertEqual(pen.contours[-1]["identifier"], 'contour 1')
+
+    def test_pen_with_lines_and_curves_strict(self):
+        pen = MathGlyphPen(strict=True)
+        pen.beginPath(identifier="contour 1")
+        pen.addPoint((0,   50), "curve", smooth=False, name="name 1",
+                     identifier="point 1")
+        pen.addPoint((50, 100), "line",  smooth=False, name="name 2",
+                     identifier="point 2")
+        pen.addPoint((75, 100), None)
+        pen.addPoint((100, 75), None)
+        pen.addPoint((100, 50), "curve", smooth=True,  name="name 3",
+                     identifier="point 3")
+        pen.addPoint((100, 25), None)
+        pen.addPoint((75,   0), None)
+        pen.addPoint((50,   0), "curve", smooth=False, name="name 4",
+                     identifier="point 4")
+        pen.addPoint((25,   0), None)
+        pen.addPoint((0,   25), None)
+        pen.endPath()
+        expected = [
+            ("curve", (0,   50), False, "name 1", "point 1"),
+            ("line", (50, 100), False, "name 2", "point 2"),
             (None,    (75, 100), False, None,     None),
             (None,    (100, 75), False, None,     None),
             ("curve", (100, 50), True, "name 3", "point 3"),


### PR DESCRIPTION
This introduces the idea of `strict` interpretation and procession of the outlines. 
* line segments are not converted to curve segments with `(0,0)` control points.
* offcurves stacked on on-curves are not filtered out when extracting.

See #232.

I added tests and they work fine, but can someone else also look at it? I'm also open for any other process that will get this behaviour into fontMath.