### PR TITLE
Test groups for equality before doing fontMath kerning math

### DIFF
--- a/Lib/fontMath/mathKerning.py
+++ b/Lib/fontMath/mathKerning.py
@@ -168,6 +168,10 @@ class MathKerning(object):
         return k
 
     def _processMathOne(self, other, funct):
+        g1 = self.groups()
+        g2 = other.groups()
+        if g1 != g2:
+            raise ValueError("Kerning groups must be exactly the same.")
         comboPairs = set(self._kerning.keys()) | set(other._kerning.keys())
         kerning = dict.fromkeys(comboPairs, None)
         for k in comboPairs:
@@ -175,17 +179,7 @@ class MathKerning(object):
             v2 = other.get(k)
             v = funct(v1, v2)
             kerning[k] = v
-        g1 = self.groups()
-        g2 = other.groups()
-        if g1 == g2 or not g1 or not g2:
-            groups = g1 or g2
-        else:
-            comboGroups = set(g1.keys()) | set(g2.keys())
-            groups = dict.fromkeys(comboGroups, None)
-            for groupName in comboGroups:
-                s1 = set(g1.get(groupName, []))
-                s2 = set(g2.get(groupName, []))
-                groups[groupName] = sorted(list(s1 | s2))
+        groups = g1 or g2
         ks = MathKerning(kerning, groups)
         return ks
 

--- a/Lib/fontMath/test/test_mathKerning.py
+++ b/Lib/fontMath/test/test_mathKerning.py
@@ -115,7 +115,7 @@ class MathKerningTest(unittest.TestCase):
         obj2 = obj1.copy()
         self.assertEqual(sorted(obj1.items()), sorted(obj2.items()))
 
-    def test_add(self):
+    def test_add_different_groups(self):
         kerning1 = {
             ("A", "A"): 1,
             ("B", "B"): 1,
@@ -140,21 +140,8 @@ class MathKerningTest(unittest.TestCase):
             "public.kern1.D": ["D", "H"],
             "public.kern2.D": ["D", "H"],
         }
-        obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
-        self.assertEqual(
-            sorted(obj.items()),
-            [(('B', 'B'), 2),
-             (('NotIn1', 'NotIn1'), 1),
-             (('NotIn2', 'NotIn2'), 1),
-             (('public.kern1.D', 'public.kern2.D'), 2),
-             (('public.kern1.NotIn1', 'C'), 1),
-             (('public.kern1.NotIn2', 'C'), 1)])
-        self.assertEqual(
-            obj.groups()["public.kern1.D"],
-            ['D', 'H'])
-        self.assertEqual(
-            obj.groups()["public.kern2.D"],
-            ['D', 'H'])
+        with self.assertRaises(ValueError):
+            obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
 
     def test_add_same_groups(self):
         kerning1 = {
@@ -195,7 +182,7 @@ class MathKerningTest(unittest.TestCase):
             obj.groups()["public.kern2.D"],
             ['D', 'H'])
 
-    def test_sub(self):
+    def test_sub_different_groups(self):
         kerning1 = {
             ("A", "A"): 1,
             ("B", "B"): 1,
@@ -220,14 +207,36 @@ class MathKerningTest(unittest.TestCase):
             "public.kern1.D": ["D"],
             "public.kern2.D": ["D", "H"],
         }
+        with self.assertRaises(ValueError):
+            obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
+
+    def test_sub_same_groups(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
         obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
         self.assertEqual(
             sorted(obj.items()),
             [(('A', 'A'), 2),
              (('NotIn1', 'NotIn1'), -1),
-             (('NotIn2', 'NotIn2'), 1),
-             (('public.kern1.NotIn1', 'C'), -1),
-             (('public.kern1.NotIn2', 'C'), 1)])
+             (('NotIn2', 'NotIn2'), 1)])
         self.assertEqual(
             obj.groups()["public.kern1.D"],
             ['D', 'H'])

--- a/Lib/fontMath/test/test_mathKerning.py
+++ b/Lib/fontMath/test/test_mathKerning.py
@@ -115,7 +115,7 @@ class MathKerningTest(unittest.TestCase):
         obj2 = obj1.copy()
         self.assertEqual(sorted(obj1.items()), sorted(obj2.items()))
 
-    def test_add_different_groups(self):
+    def test_add_different_groups_strict(self):
         kerning1 = {
             ("A", "A"): 1,
             ("B", "B"): 1,
@@ -141,7 +141,50 @@ class MathKerningTest(unittest.TestCase):
             "public.kern2.D": ["D", "H"],
         }
         with self.assertRaises(ValueError):
-            obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
+            obj = MathKerning(kerning1, groups1, strictGroups=True) + MathKerning(kerning2, groups2)
+        with self.assertRaises(ValueError):
+            obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2, strictGroups=True)
+
+    def test_add_different_groups(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.NotIn1": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.NotIn1", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.NotIn2": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj = MathKerning(kerning1, groups1) + MathKerning(kerning2, groups2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('B', 'B'), 2),
+             (('NotIn1', 'NotIn1'), 1),
+             (('NotIn2', 'NotIn2'), 1),
+             (('public.kern1.D', 'public.kern2.D'), 2),
+             (('public.kern1.NotIn1', 'C'), 1),
+             (('public.kern1.NotIn2', 'C'), 1)])
+        self.assertEqual(
+            obj.groups()["public.kern1.D"],
+            ['D', 'H'])
+        self.assertEqual(
+            obj.groups()["public.kern2.D"],
+            ['D', 'H'])
 
     def test_add_same_groups(self):
         kerning1 = {
@@ -182,7 +225,7 @@ class MathKerningTest(unittest.TestCase):
             obj.groups()["public.kern2.D"],
             ['D', 'H'])
 
-    def test_sub_different_groups(self):
+    def test_sub_different_groups_strict(self):
         kerning1 = {
             ("A", "A"): 1,
             ("B", "B"): 1,
@@ -208,7 +251,49 @@ class MathKerningTest(unittest.TestCase):
             "public.kern2.D": ["D", "H"],
         }
         with self.assertRaises(ValueError):
-            obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
+            obj = MathKerning(kerning1, groups1, strictGroups=True) - MathKerning(kerning2, groups2)
+        with self.assertRaises(ValueError):
+            obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2, strictGroups=True)
+
+    def test_sub_different_groups(self):
+        kerning1 = {
+            ("A", "A"): 1,
+            ("B", "B"): 1,
+            ("NotIn2", "NotIn2"): 1,
+            ("public.kern1.NotIn2", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups1 = {
+            "public.kern1.NotIn1": ["C"],
+            "public.kern1.D": ["D", "H"],
+            "public.kern2.D": ["D", "H"],
+        }
+        kerning2 = {
+            ("A", "A"): -1,
+            ("B", "B"): 1,
+            ("NotIn1", "NotIn1"): 1,
+            ("public.kern1.NotIn1", "C"): 1,
+            ("public.kern1.D", "public.kern2.D"): 1,
+        }
+        groups2 = {
+            "public.kern1.NotIn2": ["C"],
+            "public.kern1.D": ["D"],
+            "public.kern2.D": ["D", "H"],
+        }
+        obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)
+        self.assertEqual(
+            sorted(obj.items()),
+            [(('A', 'A'), 2),
+             (('NotIn1', 'NotIn1'), -1),
+             (('NotIn2', 'NotIn2'), 1),
+             (('public.kern1.NotIn1', 'C'), -1),
+             (('public.kern1.NotIn2', 'C'), 1)])
+        self.assertEqual(
+            obj.groups()["public.kern1.D"],
+            ['D', 'H'])
+        self.assertEqual(
+            obj.groups()["public.kern2.D"],
+            ['D', 'H'])
 
     def test_sub_same_groups(self):
         kerning1 = {
@@ -228,7 +313,7 @@ class MathKerningTest(unittest.TestCase):
             ("public.kern1.D", "public.kern2.D"): 1,
         }
         groups2 = {
-            "public.kern1.D": ["D", "H"],
+            "public.kern1.D": ["D"],
             "public.kern2.D": ["D", "H"],
         }
         obj = MathKerning(kerning1, groups1) - MathKerning(kerning2, groups2)


### PR DESCRIPTION
This fixes #22, but will be breaking to a lot of code (though it's more correct). Perhaps better to add a `strict` option?