### PR TITLE
Do not re-cycle the outline in strict mode

### DIFF
--- a/Lib/fontMath/mathGlyph.py
+++ b/Lib/fontMath/mathGlyph.py
@@ -381,18 +381,19 @@ class MathGlyphPen(AbstractPointPen):
         contourPoints = self.contours[-1]["points"]
         points = self._points
         # move offcurves at the beginning of the contour to the end
-        haveOnCurve = False
-        for point in points:
-            if point[0] is not None:
-                haveOnCurve = True
-                break
-        if haveOnCurve:
-            while 1:
-                if points[0][0] is None:
-                    point = points.pop(0)
-                    points.append(point)
-                else:
+        if not self.strict:
+            haveOnCurve = False
+            for point in points:
+                if point[0] is not None:
+                    haveOnCurve = True
                     break
+            if haveOnCurve:
+                while 1:
+                    if points[0][0] is None:
+                        point = points.pop(0)
+                        points.append(point)
+                    else:
+                        break
         # convert lines to curves
         holdingOffCurves = []
         for index, point in enumerate(points):


### PR DESCRIPTION
FontMath currently moves the off-curves of a contour from the beginning to the end while doing math on a glyph. The upshot of this is that, even in "strict" mode, the output contours are not compatible with the input contours. This means you can't add instances as masters to an interpolation, which seems a needless restriction.