### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,6 +23,11 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment:
+      name: publish-to-pypi
+      url: https://pypi.org/p/fontMath
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing.
 
     steps:
     - uses: actions/checkout@v3.5.3
@@ -35,9 +40,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
In light of the recent npm supply chain attacks and also https://blog.pypi.org/posts/2025-09-16-github-actions-token-exfiltration/, I'm combing through our font stack to see if all them Py projects are using the trusted publisher mechanism as recommended by PyPI. See https://docs.pypi.org/trusted-publishers/ and https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi.

Someone needs to do three things for this PR to work:

* Create an environment called "publish-to-pypi" in this GitHub repository under Settings -> Environments. Creating alone is probably enough, no configuration needed I think.
* Follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to set up the other side on PyPI.
* Remove tokens/secret variables here so they can't be exfiltrated anymore, and probably also remove them from PyPI.

I'm not sure if one needs to do anything to make twine pick up the new creds, trusted publishing should be supported in v6.1.0.